### PR TITLE
Add content type icon

### DIFF
--- a/ftw/redirector/browser/configure.zcml
+++ b/ftw/redirector/browser/configure.zcml
@@ -2,9 +2,12 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.redirector">
 
     <browser:resourceDirectory name="ftw.redirector" directory="resources" />
+
+    <include file="resources.zcml" zcml:condition="installed ftw.theming" />
 
     <browser:page
         name="plone_redirector_view"

--- a/ftw/redirector/browser/resources.zcml
+++ b/ftw/redirector/browser/resources.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:theme="http://namespaces.zope.org/ftw.theming"
+    i18n_domain="ftw.redirector">
+
+    <include package="ftw.theming" file="meta.zcml"/>
+
+    <theme:resources profile="ftw.redirector:default" slot="addon">
+        <theme:scss file="resources/redirector-theming.scss" />
+    </theme:resources>
+
+</configure>

--- a/ftw/redirector/browser/resources/redirector-theming.scss
+++ b/ftw/redirector/browser/resources/redirector-theming.scss
@@ -1,0 +1,1 @@
+@include portal-type-font-awesome-icon(ftw-redirector-redirectconfig, forward);


### PR DESCRIPTION
Adds a content type icon for ftw.redirector when ftw.theming is installed.

example (bl.web):
![bildschirmfoto 2016-08-26 um 11 08 00](https://cloud.githubusercontent.com/assets/16755391/18000246/69fcf76c-6b7d-11e6-827f-c2cf21c3e7a3.png)

closes #3
