### PR TITLE
Pin down openpyxl.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Require `openpyxl < 2.6` since newer ones no longer support Python 2.7 [jone]
 - Add support for Plone 5.1.x. [mbaechtold]
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(name='ftw.redirector',
       install_requires=[
           'collective.z3cform.datagridfield',
           'ftw.profilehook',
-          'openpyxl',
+          'openpyxl < 2.6',
           'plone.api',
           'plone.app.dexterity',
           'plone.dexterity',


### PR DESCRIPTION
openpyxl 2.6 does no longer support python 2.7.

Fixes https://ci.4teamwork.ch/builds/224042/tasks/368332
```python
1550794959.180.470763650875 http://nohost/plone/redirect-config/export
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module ftw.redirector.browser.excel_views, line 35, in __call__
  Module ftw.redirector.excel, line 59, in create_rules_excel
  Module openpyxl.utils.bound_dictionary, line 26, in __getitem__
  Module openpyxl.descriptors.base, line 44, in __set__
TypeError: expected <type 'basestring'>

ftw.testbrowser dump: /tmp/ftw.testbrowser-NR1X1u.html

Error in test test_excel_views_are_available (ftw.redirector.tests.test_excel_export_import.TestRedirectConfigExportImport)
Traceback (most recent call last):
  File "/var/lib/jenkins/zope/eggs/unittest2-0.5.1-py2.7.egg/unittest2/case.py", line 340, in run
    testMethod()
  File "/var/lib/jenkins/zope/eggs/ftw.testbrowser-1.30.1-py2.7.egg/ftw/testbrowser/__init__.py", line 42, in test_function
    return func(self, *args, **kwargs)
  File "/var/lib/jenkins/jobs/ftw.redirector/workspace/ftw/redirector/tests/test_excel_export_import.py", line 25, in test_excel_views_are_available
    browser.open(IRedirectConfig(self.portal), view='export')
  File "/var/lib/jenkins/zope/eggs/ftw.testbrowser-1.30.1-py2.7.egg/ftw/testbrowser/core.py", line 283, in open
    self.raise_for_status(logger)
  File "/var/lib/jenkins/zope/eggs/ftw.testbrowser-1.30.1-py2.7.egg/ftw/testbrowser/core.py", line 296, in raise_for_status
    raise HTTPServerError(self.status_code, self.status_reason)
HTTPServerError: 500 Internal Server Error
```