### PR TITLE
Fix tests by pinning down c.z.datagridfield to a Plone 4 compatible version

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -3,3 +3,7 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
 
 package-name = ftw.redirector
+
+[versions]
+# Plone 4 support got dropped in 1.4.0
+collective.z3cform.datagridfield = <1.4.0


### PR DESCRIPTION
Fix tests by pinning down `collective.z3cform.datagridfield` to a Plone 4 compatible version.

Plone 4 support got [dropped in `1.4.0`](https://github.com/collective/collective.z3cform.datagridfield/blob/master/CHANGES.rst#140-2019-02-21), which now contains a hard dependency on Plone 5.

Fixes this failure: https://ci.4teamwork.ch/builds/228454/tasks/375226